### PR TITLE
[Feature/login] modify typo in detailed page and css of navigation bar

### DIFF
--- a/src/main/resources/static/css/detail-page.css
+++ b/src/main/resources/static/css/detail-page.css
@@ -23,6 +23,7 @@ body {
 .header .nav {
     display: flex;
     gap: 15px;
+    align-items: center;
 }
 .header .nav a {
     text-decoration: none;

--- a/src/main/resources/static/css/navigation.css
+++ b/src/main/resources/static/css/navigation.css
@@ -1,14 +1,22 @@
 /* src/main/resources/static/css/navigation.css */
 @import url('reset.css');
+
+.nav {
+    display: flex;
+    align-items: center;
+}
 /*현재 유저 프사 */
 .current-user {
     width: 40px;
+    height: 40px;
+    border-radius: 50%;
 }
 
+/* 이 부분 위의 .current-user의 css랑 겹쳐서 적용 안 되는 거 같음 */
 .current-user img {
-    width: 30px; /* 프로필 이미지 크기 */
-    height: 30px;
-    border-radius: 50px; /* 원형으로 만들기 */
+    /*width: 30px; !* 프로필 이미지 크기 *!*/
+    /*height: 30px;*/
+    /*border-radius: 50px; !* 원형으로 만들기 *!*/
 }
 
 /* 오른쪽 네이게이션 스타일 */
@@ -35,6 +43,7 @@
     text-decoration: none;
     color: #555;
     font-size: 16px;
+    margin-left: 15px;
     transition: color 0.3s ease;
 }
 

--- a/src/main/webapp/WEB-INF/views/components/detail-page.jsp
+++ b/src/main/webapp/WEB-INF/views/components/detail-page.jsp
@@ -49,7 +49,7 @@
     <span>반려동물</span>
     <span>육아</span>
     <span>홈스토랑</span>
-    <span>플랜테니어</span>
+    <span>플랜테리어</span>
     <span>콜렉터블</span>
     <span>캠핑</span>
     <span>이벤트</span>


### PR DESCRIPTION
1. 디테일 페이지에 navigation 메뉴에서 '플랜테니어' -> '플랜테리어'로 수정했습니다

2. navigation bar의 메뉴 글씨가 nav 바 세로 가운데 정렬 되도록 하였습ㄴ디ㅏ.
![image](https://github.com/user-attachments/assets/3640a0fa-353d-4b39-b9e4-a16a979f19d5)
