### PR TITLE
[Feature/login] css of navigation bar in main menu

### DIFF
--- a/src/main/resources/static/css/auth/pages/login.css
+++ b/src/main/resources/static/css/auth/pages/login.css
@@ -25,7 +25,6 @@
 /* 클론 글씨체 */
 @font-face {
     font-family: 'PretendardVariable';
-    src: url('/fonts/23b386a66fd50.woff2') format('woff2'),
     url('/fonts/PretendardVariable.subset.91.woff2') format('woff2'),
     url('/fonts/PretendardVariable.subset.88.woff2') format('woff2'),
     url('/fonts/PretendardVariable.subset.90.woff2') format('woff2'),

--- a/src/main/resources/static/css/auth/pages/signUp.css
+++ b/src/main/resources/static/css/auth/pages/signUp.css
@@ -27,7 +27,6 @@
 /* 클론 글씨체 */
 @font-face {
     font-family: 'PretendardVariable';
-    src: url('/fonts/23b386a66fd50.woff2') format('woff2'),
     url('/fonts/PretendardVariable.subset.91.woff2') format('woff2'),
     url('/fonts/PretendardVariable.subset.88.woff2') format('woff2'),
     url('/fonts/PretendardVariable.subset.90.woff2') format('woff2'),

--- a/src/main/resources/static/css/categoryList.css
+++ b/src/main/resources/static/css/categoryList.css
@@ -6,7 +6,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 20px 80px; /* 상하 20px, 좌우 80px */
+    /* padding 상하 : 프로필 이미지 사진이 추가되어서, 상하 20px 으로 하는 것보다 10px으로 하는 것이 디자인 적으로 나음 */
+    padding: 10px 60px; /* 상하 20px, 좌우 80px */
     background-color: #f1f1f1;
     border-bottom: 1px solid #ddd;
 }

--- a/src/main/resources/static/css/navigation.css
+++ b/src/main/resources/static/css/navigation.css
@@ -10,6 +10,7 @@
     width: 40px;
     height: 40px;
     border-radius: 50%;
+    object-fit: cover;
 }
 
 /* 이 부분 위의 .current-user의 css랑 겹쳐서 적용 안 되는 거 같음 */

--- a/src/main/resources/static/css/reset.css
+++ b/src/main/resources/static/css/reset.css
@@ -9,7 +9,6 @@
 
 @font-face {
     font-family: 'PretendardVariable';
-    src: url('/fonts/23b386a66fd50.woff2') format('woff2'),
     url('/fonts/PretendardVariable.subset.91.woff2') format('woff2'),
     url('/fonts/PretendardVariable.subset.88.woff2') format('woff2'),
     url('/fonts/PretendardVariable.subset.90.woff2') format('woff2'),


### PR DESCRIPTION
1. 아래 글씨체는 에러 나서 없앰
23b386a66fd50.woff2

2. main page navigation 바의 세로 여백 50%로 줄임(detailed page 랑 크기 비슷하게)