### PR TITLE
[Feature/index] modify main css

### DIFF
--- a/src/main/resources/static/css/post.css
+++ b/src/main/resources/static/css/post.css
@@ -34,7 +34,7 @@
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    object-fit: scale-down;
+    object-fit: cover;
     margin-right: 10px;
 }
 .post-item .post-profile .profile-info {


### PR DESCRIPTION
메인페이지 post 렌더링 시 프로필 사진이 캡처 같이 짤리는 것 수정(object-fit을 scale-down에서 cover로)

![image](https://github.com/user-attachments/assets/fb81aa8a-3c93-4957-863a-39cea2da5e08)
